### PR TITLE
fix: tolerate Codex 0.133 thread/start service tier and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codex-file-search"
-version = "1.3.2"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "clap",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "1.3.2"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "codex-potter-cli"
-version = "1.3.2"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "1.3.2"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "icu_decimal",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "1.3.2"
+version = "0.1.33"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codex-file-search"
-version = "0.0.0"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.0.0"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "codex-potter-cli"
-version = "0.0.0"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.0.0"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "icu_decimal",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "0.0.0"
+version = "1.3.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cli", "protocol", "tui", "file-search", "hooks"]
 resolver = "2"
 
 [workspace.package]
-version = "1.3.2"
+version = "0.1.33"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cli", "protocol", "tui", "file-search", "hooks"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.0"
+version = "1.3.2"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024

--- a/cli/src/app_server/upstream_protocol/protocol/v2.rs
+++ b/cli/src/app_server/upstream_protocol/protocol/v2.rs
@@ -101,6 +101,26 @@ fn upstream_http_status_code(value: JsonValue) -> Option<u16> {
         .and_then(|status| u16::try_from(status).ok())
 }
 
+/// Decode an upstream response service tier while tolerating values Potter does not model
+/// explicitly.
+///
+/// Current Codex builds can return `"default"` in thread metadata. Potter only has distinct UX
+/// for `fast` and `flex`, so anything else should degrade to `None` instead of failing the whole
+/// response decode.
+pub fn service_tier_from_value(value: &JsonValue) -> Option<ServiceTier> {
+    serde_json::from_value::<ServiceTier>(value.clone()).ok()
+}
+
+fn deserialize_response_service_tier_opt<'de, D>(
+    deserializer: D,
+) -> Result<Option<ServiceTier>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<JsonValue>::deserialize(deserializer)?;
+    Ok(value.as_ref().and_then(service_tier_from_value))
+}
+
 /// Upstream approval policy for agent tool executions.
 ///
 /// CodexPotter typically sets this to [`AskForApproval::Never`] and handles any "approval"-like
@@ -753,6 +773,7 @@ pub struct ThreadStartResponse {
     pub thread: Thread,
     pub model: String,
     pub model_provider: String,
+    #[serde(default, deserialize_with = "deserialize_response_service_tier_opt")]
     pub service_tier: Option<ServiceTier>,
     pub cwd: PathBuf,
     #[serde(default)]
@@ -797,6 +818,7 @@ pub struct ThreadResumeResponse {
     pub thread: Thread,
     pub model: String,
     pub model_provider: String,
+    #[serde(default, deserialize_with = "deserialize_response_service_tier_opt")]
     pub service_tier: Option<ServiceTier>,
     pub cwd: PathBuf,
     #[serde(default)]
@@ -1711,6 +1733,32 @@ mod tests {
 
         assert_eq!(response.approvals_reviewer, ApprovalsReviewer::AutoReview);
         assert_eq!(response.permission_profile, None);
+    }
+
+    #[test]
+    fn thread_start_response_tolerates_default_service_tier() {
+        let response: ThreadStartResponse = serde_json::from_value(json!({
+            "thread": {
+                "id": "thread-1"
+            },
+            "model": "gpt-5.4",
+            "modelProvider": "openai",
+            "serviceTier": "default",
+            "cwd": "/tmp/worktree",
+            "instructionSources": [],
+            "approvalPolicy": "never",
+            "approvalsReviewer": "user",
+            "sandbox": {
+                "type": "dangerFullAccess"
+            },
+            "permissionProfile": null,
+            "reasoningEffort": "high",
+            "activePermissionProfile": null,
+            "runtimeWorkspaceRoots": ["/tmp/worktree"]
+        }))
+        .expect("deserialize thread/start response with default service tier");
+
+        assert_eq!(response.service_tier, None);
     }
 
     #[test]

--- a/cli/src/workflow/replay_session_config.rs
+++ b/cli/src/workflow/replay_session_config.rs
@@ -17,6 +17,8 @@ use codex_protocol::ThreadId;
 use codex_protocol::protocol::ServiceTier;
 use codex_protocol::protocol::SessionConfiguredEvent;
 
+use crate::app_server::upstream_protocol::service_tier_from_value;
+
 /// Resolve a recorded upstream rollout path against the original project working directory.
 pub fn resolve_rollout_path_for_replay(workdir: &Path, rollout_path: &Path) -> PathBuf {
     if rollout_path.is_absolute() {
@@ -119,7 +121,7 @@ fn read_rollout_context_snapshot(
                 if service_tier.is_none()
                     && let Some(v) = payload.get("service_tier")
                 {
-                    service_tier = serde_json::from_value::<ServiceTier>(v.clone()).ok();
+                    service_tier = service_tier_from_value(v);
                 }
             }
             _ => {}
@@ -204,5 +206,28 @@ mod tests {
         .expect("session configured");
 
         assert_eq!(cfg.service_tier, Some(ServiceTier::Flex));
+    }
+
+    #[test]
+    fn synthesize_session_configured_event_ignores_default_snapshot_service_tier() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let rollout_path = temp.path().join("rollout.jsonl");
+        std::fs::write(
+            &rollout_path,
+            r#"{"timestamp":"2026-02-28T00:00:00.000Z","type":"turn_context","payload":{"cwd":"project","approval_policy":"never","sandbox_policy":{"type":"read_only"},"model":"test-model","summary":{"type":"auto"},"output_schema":null}}
+{"timestamp":"2026-02-28T00:00:01.000Z","type":"session_meta","payload":{"model_provider":"openai","service_tier":"default"}}
+"#,
+        )
+        .expect("write rollout");
+
+        let cfg = synthesize_session_configured_event(
+            ThreadId::from_string("019ca423-63d9-7641-ae83-db060ad3c000").expect("thread id"),
+            None,
+            rollout_path,
+        )
+        .expect("synthesize")
+        .expect("session configured");
+
+        assert_eq!(cfg.service_tier, None);
     }
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-potter",
-  "version": "1.3.2",
+  "version": "0.1.33",
   "license": "Apache-2.0",
   "bin": {
     "codex-potter": "bin/codex-potter.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-potter",
-  "version": "0.0.0-dev",
+  "version": "1.3.2",
   "license": "Apache-2.0",
   "bin": {
     "codex-potter": "bin/codex-potter.js"


### PR DESCRIPTION
Summary:
- tolerate unknown response-side serviceTier values such as "default" from Codex 0.133.0
- keep replay metadata compatible when stored service_tier is "default"
- bump CodexPotter version from 0.1.32 to 0.1.33 to keep local builds aligned with the published CodexPotter version line

Verification:
- cargo test -p codex-potter-cli thread_start_response_tolerates_default_service_tier
- cargo test -p codex-potter-cli synthesize_session_configured_event_ignores_default_snapshot_service_tier
- cargo build -p codex-potter-cli --release

Notes:
- full cargo test -p codex-potter-cli still has unrelated pre-existing Windows failures in this checkout
